### PR TITLE
Fix missing field in prod data

### DIFF
--- a/organizer/src/class/Thread.php
+++ b/organizer/src/class/Thread.php
@@ -11,6 +11,7 @@ class Thread {
     var $sent;
     var $archived;
     var $public = false;
+    var $sentComment; // Added property
 
     /* @var ThreadEmail[] $emails */
     var $emails;

--- a/organizer/src/class/ThreadFileOperations.php
+++ b/organizer/src/class/ThreadFileOperations.php
@@ -20,6 +20,7 @@ function getThreads() {
                 foreach ($thread as $key => $value) {
                     $threadObj->$key = $value;
                 }
+                $threadObj->sentComment = isset($thread->sentComment) ? $thread->sentComment : null; // Initialize sentComment
                 $thread = $threadObj;
             }
         }
@@ -46,6 +47,7 @@ if (!function_exists('getThreadsForEntity')) {
                 foreach ($thread as $key => $value) {
                     $threadObj->$key = $value;
                 }
+                $threadObj->sentComment = isset($thread->sentComment) ? $thread->sentComment : null; // Initialize sentComment
                 $thread = $threadObj;
             }
         }

--- a/organizer/src/tests/ThreadFileOperationsTest.php
+++ b/organizer/src/tests/ThreadFileOperationsTest.php
@@ -160,4 +160,44 @@ class ThreadFileOperationsTest extends TestCase {
         $this->assertNotNull($result);
         $this->assertEquals('Test Comment', $result->threads[0]->sentComment);
     }
+
+    public function testCreateThread() {
+        $entityId = 'test-entity';
+        $entityTitlePrefix = 'Test Prefix';
+        $thread = new Thread();
+        $thread->title = 'Test Thread';
+        $thread->sentComment = 'Test Comment';
+
+        $createdThread = createThread($entityId, $entityTitlePrefix, $thread);
+
+        $this->assertEquals('Test Thread', $createdThread->title);
+        $this->assertEquals('Test Comment', $createdThread->sentComment);
+
+        $savedThreads = getThreadsForEntity($entityId);
+        $this->assertNotNull($savedThreads);
+        $this->assertEquals('Test Prefix', $savedThreads->title_prefix);
+        $this->assertCount(1, $savedThreads->threads);
+        $this->assertEquals('Test Thread', $savedThreads->threads[0]->title);
+        $this->assertEquals('Test Comment', $savedThreads->threads[0]->sentComment);
+    }
+
+    public function testSaveEntityThreads() {
+        $entityId = 'test-entity';
+        $threads = new Threads();
+        $threads->entity_id = $entityId;
+        $threads->title_prefix = 'Test Prefix';
+        $thread = new Thread();
+        $thread->title = 'Test Thread';
+        $thread->sentComment = 'Test Comment';
+        $threads->threads = [$thread];
+
+        saveEntityThreads($entityId, $threads);
+
+        $savedThreads = getThreadsForEntity($entityId);
+        $this->assertNotNull($savedThreads);
+        $this->assertEquals('Test Prefix', $savedThreads->title_prefix);
+        $this->assertCount(1, $savedThreads->threads);
+        $this->assertEquals('Test Thread', $savedThreads->threads[0]->title);
+        $this->assertEquals('Test Comment', $savedThreads->threads[0]->sentComment);
+    }
 }

--- a/organizer/src/tests/ThreadFileOperationsTest.php
+++ b/organizer/src/tests/ThreadFileOperationsTest.php
@@ -124,4 +124,40 @@ class ThreadFileOperationsTest extends TestCase {
         
         getThreadFile($entityId, $threadId, $attachmentName);
     }
+
+    public function testSentCommentInitializationInGetThreads() {
+        // Create a thread file with sentComment
+        $thread = new Thread();
+        $thread->title = 'Test Thread';
+        $thread->sentComment = 'Test Comment';
+        $threads = new Threads();
+        $threads->threads = [$thread];
+        file_put_contents(
+            joinPaths($this->threadsDir, 'threads-test.json'),
+            json_encode($threads)
+        );
+
+        $result = getThreads();
+        $this->assertCount(1, $result);
+        $this->assertArrayHasKey(realpath(joinPaths($this->threadsDir, 'threads-test.json')), $result);
+        $this->assertEquals('Test Comment', $result[realpath(joinPaths($this->threadsDir, 'threads-test.json'))]->threads[0]->sentComment);
+    }
+
+    public function testSentCommentInitializationInGetThreadsForEntity() {
+        // Create a thread file with sentComment
+        $thread = new Thread();
+        $thread->title = 'Test Thread';
+        $thread->sentComment = 'Test Comment';
+        $threads = new Threads();
+        $threads->entity_id = 'test-entity';
+        $threads->threads = [$thread];
+        file_put_contents(
+            joinPaths($this->threadsDir, 'threads-test-entity.json'),
+            json_encode($threads)
+        );
+
+        $result = getThreadsForEntity('test-entity');
+        $this->assertNotNull($result);
+        $this->assertEquals('Test Comment', $result->threads[0]->sentComment);
+    }
 }


### PR DESCRIPTION
Add `sentComment` property to `Thread` class and initialize it in relevant functions.

* **Thread.php**
  - Add `sentComment` property to the `Thread` class.

* **ThreadFileOperations.php**
  - Initialize `sentComment` property when converting threads to `Thread` objects in the `getThreads` function.
  - Initialize `sentComment` property when converting threads to `Thread` objects in the `getThreadsForEntity` function.

* **ThreadFileOperationsTest.php**
  - Add test case to verify `sentComment` property initialization in the `getThreads` function.
  - Add test case to verify `sentComment` property initialization in the `getThreadsForEntity` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HNygard/offpost/pull/1?shareId=e1101807-343f-4339-9358-017e8fc6663b).