### PR TITLE
Add GitHub Actions workflow for PHP project

### DIFF
--- a/organizer/.github/workflows/php.yml
+++ b/organizer/.github/workflows/php.yml
@@ -1,0 +1,32 @@
+name: PHP CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-versions: [8.2]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+
+    - name: Install dependencies
+      run: composer install
+
+    - name: Run tests
+      run: vendor/bin/phpunit


### PR DESCRIPTION
Add a GitHub Actions workflow for PHP project with unit tests.

* **Workflow Configuration**
  - Define the workflow to run on push and pull request events for the main branch.
  - Set up the job to run on `ubuntu-latest` with PHP version 8.2.
  - Include steps to checkout code, set up PHP, install dependencies using Composer, and run PHPUnit tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HNygard/offpost/pull/2?shareId=4bb22f13-3e20-496b-a3e6-96313c9aa075).