### PR TITLE
Fix composer install directory in GitHub workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -26,7 +26,7 @@ jobs:
         php-version: ${{ matrix.php-versions }}
 
     - name: Install dependencies
-      run: composer install
+      run: cd organizer/src && composer install
 
     - name: Run tests
-      run: vendor/bin/phpunit
+      run: cd organizer/src && vendor/bin/phpunit


### PR DESCRIPTION
Update the GitHub Actions workflow to run `composer install` and `vendor/bin/phpunit` in the correct directory.

* Change the `composer install` command to `cd organizer/src && composer install` in the `.github/workflows/php.yml` file.
* Change the `vendor/bin/phpunit` command to `cd organizer/src && vendor/bin/phpunit` in the `.github/workflows/php.yml` file.

