### PR TITLE
Update GitHub Action workflow to exclude integration tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,4 +29,4 @@ jobs:
       run: cd organizer/src && composer install
 
     - name: Run tests
-      run: cd organizer/src && vendor/bin/phpunit tests
+      run: cd organizer/src && vendor/bin/phpunit --exclude-group integration tests

--- a/organizer/src/tests/ThreadEmailReceiveIntegrationTest.php
+++ b/organizer/src/tests/ThreadEmailReceiveIntegrationTest.php
@@ -148,6 +148,7 @@ class ThreadEmailReceiveIntegrationTest extends TestCase {
     }
 
     /**
+     * @group integration
      * This test checks what happens when we receive emails in our system from a public entity.
      */
     public function testReceiveEmail() {

--- a/organizer/src/tests/ThreadEmailSendingIntegrationTest.php
+++ b/organizer/src/tests/ThreadEmailSendingIntegrationTest.php
@@ -147,6 +147,9 @@ class ThreadEmailSendingIntegrationTest extends TestCase {
         return null;
     }
 
+    /**
+     * @group integration
+     */
     public function testStartThread() {
         // Create unique test data
         $uniqueId = uniqid();


### PR DESCRIPTION
Update the GitHub Action workflow to exclude integration tests and add group annotations to specific test functions.

* **GitHub Action Workflow**
  - Update the `Run tests` step to exclude the `integration` group in `.github/workflows/php.yml`.

* **ThreadEmailSendingIntegrationTest**
  - Add `@group integration` annotation to the `testStartThread` function in `organizer/src/tests/ThreadEmailSendingIntegrationTest.php`.

* **ThreadEmailReceiveIntegrationTest**
  - Add `@group integration` annotation to the `testReceiveEmail` function in `organizer/src/tests/ThreadEmailReceiveIntegrationTest.php`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HNygard/offpost/pull/6?shareId=38550bf1-20d5-439d-9a5e-56b4fe5d3eb9).