### PR TITLE
Add integration with OpenAI API for summarizing email responses

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -87,7 +87,6 @@ I pledge to follow the custom instructions.
 - Get into database:
     docker exec -it email-engine_postgres_1 psql -U offpost -d offpost
 
-
 ## Security
 
 ### Sensitive Files
@@ -104,3 +103,44 @@ DO NOT read or modify:
 -   Never commit sensitive files
 -   Use environment variables for secrets
 -   Keep credentials out of logs and output
+
+## OpenAI API Integration
+
+### Overview
+
+The system now includes integration with the OpenAI API for summarizing email responses. This feature helps in quickly understanding the content of received emails by providing concise summaries.
+
+### Configuration
+
+To configure the OpenAI API integration, follow these steps:
+
+1. Obtain an API key from OpenAI.
+2. Set the API key as an environment variable in your system:
+   ```bash
+   export OPENAI_API_KEY=your_api_key_here
+   ```
+
+### Usage
+
+The `ThreadEmailSummarizer` class uses the `OpenAIClient` to summarize email responses. Here is an example of how to use it:
+
+```php
+require_once 'class/ThreadEmailSummarizer.php';
+
+$apiKey = getenv('OPENAI_API_KEY');
+$summarizer = new ThreadEmailSummarizer($apiKey);
+
+$emailContent = "Your email content here";
+$summary = $summarizer->summarize($emailContent);
+
+echo "Summary: " . $summary;
+```
+
+### Running Tests for OpenAI Integration
+
+To run the tests related to the OpenAI API integration, use the following command:
+
+```bash
+cd organizer/src && ./vendor/bin/phpunit tests/OpenAIClientTest.php
+cd organizer/src && ./vendor/bin/phpunit tests/ThreadEmailSummarizerTest.php
+```

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "cd organizer/src && composer install"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -113,3 +113,44 @@ http://localhost:25081/start-thread.php?my_email=asmund.visnes%40offpost.no&my_n
    - Update thread details:
      - Set sent = true
      - Update status_type and status_text
+
+## OpenAI API Integration
+
+### Overview
+
+The system now includes integration with the OpenAI API for summarizing email responses. This feature helps in quickly understanding the content of received emails by providing concise summaries.
+
+### Configuration
+
+To configure the OpenAI API integration, follow these steps:
+
+1. Obtain an API key from OpenAI.
+2. Set the API key as an environment variable in your system:
+   ```bash
+   export OPENAI_API_KEY=your_api_key_here
+   ```
+
+### Usage
+
+The `ThreadEmailSummarizer` class uses the `OpenAIClient` to summarize email responses. Here is an example of how to use it:
+
+```php
+require_once 'class/ThreadEmailSummarizer.php';
+
+$apiKey = getenv('OPENAI_API_KEY');
+$summarizer = new ThreadEmailSummarizer($apiKey);
+
+$emailContent = "Your email content here";
+$summary = $summarizer->summarize($emailContent);
+
+echo "Summary: " . $summary;
+```
+
+### Running Tests for OpenAI Integration
+
+To run the tests related to the OpenAI API integration, use the following command:
+
+```bash
+cd organizer/src && ./vendor/bin/phpunit tests/OpenAIClientTest.php
+cd organizer/src && ./vendor/bin/phpunit tests/ThreadEmailSummarizerTest.php
+```

--- a/organizer/src/class/CurlWrapper.php
+++ b/organizer/src/class/CurlWrapper.php
@@ -1,0 +1,29 @@
+<?php
+
+class CurlWrapper {
+    private $curlHandle;
+
+    public function init($url) {
+        $this->curlHandle = curl_init($url);
+    }
+
+    public function setOption($option, $value) {
+        curl_setopt($this->curlHandle, $option, $value);
+    }
+
+    public function execute() {
+        return curl_exec($this->curlHandle);
+    }
+
+    public function getError() {
+        return curl_error($this->curlHandle);
+    }
+
+    public function getErrno() {
+        return curl_errno($this->curlHandle);
+    }
+
+    public function close() {
+        curl_close($this->curlHandle);
+    }
+}

--- a/organizer/src/class/OpenAIClient.php
+++ b/organizer/src/class/OpenAIClient.php
@@ -1,0 +1,43 @@
+<?php
+
+class OpenAIClient {
+    private $apiKey;
+    private $apiUrl = 'https://api.openai.com/v1/engines/davinci-codex/completions';
+
+    public function __construct($apiKey) {
+        $this->apiKey = $apiKey;
+    }
+
+    public function sendRequest($data) {
+        $ch = curl_init($this->apiUrl);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . $this->apiKey,
+        ]);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+
+        $response = curl_exec($ch);
+        if (curl_errno($ch)) {
+            throw new Exception('Request Error: ' . curl_error($ch));
+        }
+
+        curl_close($ch);
+        return json_decode($response, true);
+    }
+
+    public function summarizeEmail($emailContent) {
+        $data = [
+            'prompt' => 'Summarize the following email: ' . $emailContent,
+            'max_tokens' => 150,
+        ];
+
+        $response = $this->sendRequest($data);
+        if (isset($response['choices'][0]['text'])) {
+            return $response['choices'][0]['text'];
+        }
+
+        throw new Exception('Failed to summarize email');
+    }
+}

--- a/organizer/src/class/ThreadEmailSummarizer.php
+++ b/organizer/src/class/ThreadEmailSummarizer.php
@@ -9,6 +9,10 @@ class ThreadEmailSummarizer {
         $this->openAIClient = new OpenAIClient($apiKey);
     }
 
+    public function setOpenAIClient($openAIClient) {
+        $this->openAIClient = $openAIClient;
+    }
+
     public function summarize($emailContent) {
         return $this->openAIClient->summarizeEmail($emailContent);
     }

--- a/organizer/src/class/ThreadEmailSummarizer.php
+++ b/organizer/src/class/ThreadEmailSummarizer.php
@@ -1,0 +1,21 @@
+<?php
+
+require_once 'OpenAIClient.php';
+
+class ThreadEmailSummarizer {
+    private $openAIClient;
+
+    public function __construct($apiKey) {
+        $this->openAIClient = new OpenAIClient($apiKey);
+    }
+
+    public function summarize($emailContent) {
+        return $this->openAIClient->summarizeEmail($emailContent);
+    }
+
+    public function processEmail($email) {
+        $summary = $this->summarize($email->body);
+        $email->summary = $summary;
+        return $email;
+    }
+}

--- a/organizer/src/tests/OpenAIClientTest.php
+++ b/organizer/src/tests/OpenAIClientTest.php
@@ -3,13 +3,17 @@
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../class/OpenAIClient.php';
+require_once __DIR__ . '/../class/CurlWrapper.php';
 
 class OpenAIClientTest extends TestCase {
     private $apiKey = 'test-api-key';
     private $client;
+    private $mockCurlWrapper;
 
     protected function setUp(): void {
+        $this->mockCurlWrapper = $this->createMock(CurlWrapper::class);
         $this->client = new OpenAIClient($this->apiKey);
+        $this->client->setCurlWrapper($this->mockCurlWrapper);
     }
 
     public function testSendRequestSuccess() {
@@ -24,11 +28,8 @@ class OpenAIClientTest extends TestCase {
             ]
         ];
 
-        $mockCurl = $this->createMock(CurlHandle::class);
-        $mockCurl->method('exec')->willReturn(json_encode($mockResponse));
-        $mockCurl->method('errno')->willReturn(0);
-
-        $this->client->setCurlHandle($mockCurl);
+        $this->mockCurlWrapper->method('execute')->willReturn(json_encode($mockResponse));
+        $this->mockCurlWrapper->method('getErrno')->willReturn(0);
 
         $response = $this->client->sendRequest($data);
         $this->assertEquals($mockResponse, $response);
@@ -40,12 +41,9 @@ class OpenAIClientTest extends TestCase {
             'max_tokens' => 5,
         ];
 
-        $mockCurl = $this->createMock(CurlHandle::class);
-        $mockCurl->method('exec')->willReturn(false);
-        $mockCurl->method('errno')->willReturn(1);
-        $mockCurl->method('error')->willReturn('Test error');
-
-        $this->client->setCurlHandle($mockCurl);
+        $this->mockCurlWrapper->method('execute')->willReturn(false);
+        $this->mockCurlWrapper->method('getErrno')->willReturn(1);
+        $this->mockCurlWrapper->method('getError')->willReturn('Test error');
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Request Error: Test error');
@@ -66,11 +64,8 @@ class OpenAIClientTest extends TestCase {
             ]
         ];
 
-        $mockCurl = $this->createMock(CurlHandle::class);
-        $mockCurl->method('exec')->willReturn(json_encode($mockResponse));
-        $mockCurl->method('errno')->willReturn(0);
-
-        $this->client->setCurlHandle($mockCurl);
+        $this->mockCurlWrapper->method('execute')->willReturn(json_encode($mockResponse));
+        $this->mockCurlWrapper->method('getErrno')->willReturn(0);
 
         $summary = $this->client->summarizeEmail($emailContent);
         $this->assertEquals('Test summary', $summary);
@@ -87,11 +82,8 @@ class OpenAIClientTest extends TestCase {
             'choices' => []
         ];
 
-        $mockCurl = $this->createMock(CurlHandle::class);
-        $mockCurl->method('exec')->willReturn(json_encode($mockResponse));
-        $mockCurl->method('errno')->willReturn(0);
-
-        $this->client->setCurlHandle($mockCurl);
+        $this->mockCurlWrapper->method('execute')->willReturn(json_encode($mockResponse));
+        $this->mockCurlWrapper->method('getErrno')->willReturn(0);
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to summarize email');

--- a/organizer/src/tests/OpenAIClientTest.php
+++ b/organizer/src/tests/OpenAIClientTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../class/OpenAIClient.php';
+
+class OpenAIClientTest extends TestCase {
+    private $apiKey = 'test-api-key';
+    private $client;
+
+    protected function setUp(): void {
+        $this->client = new OpenAIClient($this->apiKey);
+    }
+
+    public function testSendRequestSuccess() {
+        $data = [
+            'prompt' => 'Test prompt',
+            'max_tokens' => 5,
+        ];
+
+        $mockResponse = [
+            'choices' => [
+                ['text' => 'Test response']
+            ]
+        ];
+
+        $mockCurl = $this->createMock(CurlHandle::class);
+        $mockCurl->method('exec')->willReturn(json_encode($mockResponse));
+        $mockCurl->method('errno')->willReturn(0);
+
+        $this->client->setCurlHandle($mockCurl);
+
+        $response = $this->client->sendRequest($data);
+        $this->assertEquals($mockResponse, $response);
+    }
+
+    public function testSendRequestError() {
+        $data = [
+            'prompt' => 'Test prompt',
+            'max_tokens' => 5,
+        ];
+
+        $mockCurl = $this->createMock(CurlHandle::class);
+        $mockCurl->method('exec')->willReturn(false);
+        $mockCurl->method('errno')->willReturn(1);
+        $mockCurl->method('error')->willReturn('Test error');
+
+        $this->client->setCurlHandle($mockCurl);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Request Error: Test error');
+
+        $this->client->sendRequest($data);
+    }
+
+    public function testSummarizeEmailSuccess() {
+        $emailContent = 'This is a test email content.';
+        $data = [
+            'prompt' => 'Summarize the following email: ' . $emailContent,
+            'max_tokens' => 150,
+        ];
+
+        $mockResponse = [
+            'choices' => [
+                ['text' => 'Test summary']
+            ]
+        ];
+
+        $mockCurl = $this->createMock(CurlHandle::class);
+        $mockCurl->method('exec')->willReturn(json_encode($mockResponse));
+        $mockCurl->method('errno')->willReturn(0);
+
+        $this->client->setCurlHandle($mockCurl);
+
+        $summary = $this->client->summarizeEmail($emailContent);
+        $this->assertEquals('Test summary', $summary);
+    }
+
+    public function testSummarizeEmailFailure() {
+        $emailContent = 'This is a test email content.';
+        $data = [
+            'prompt' => 'Summarize the following email: ' . $emailContent,
+            'max_tokens' => 150,
+        ];
+
+        $mockResponse = [
+            'choices' => []
+        ];
+
+        $mockCurl = $this->createMock(CurlHandle::class);
+        $mockCurl->method('exec')->willReturn(json_encode($mockResponse));
+        $mockCurl->method('errno')->willReturn(0);
+
+        $this->client->setCurlHandle($mockCurl);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Failed to summarize email');
+
+        $this->client->summarizeEmail($emailContent);
+    }
+}

--- a/organizer/src/tests/ThreadEmailSummarizerTest.php
+++ b/organizer/src/tests/ThreadEmailSummarizerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../class/ThreadEmailSummarizer.php';
+require_once __DIR__ . '/../class/OpenAIClient.php';
+
+class ThreadEmailSummarizerTest extends TestCase {
+    private $apiKey = 'test-api-key';
+    private $summarizer;
+    private $mockOpenAIClient;
+
+    protected function setUp(): void {
+        $this->mockOpenAIClient = $this->createMock(OpenAIClient::class);
+        $this->summarizer = new ThreadEmailSummarizer($this->apiKey);
+        $this->summarizer->openAIClient = $this->mockOpenAIClient;
+    }
+
+    public function testSummarize() {
+        $emailContent = 'This is a test email content.';
+        $expectedSummary = 'Test summary';
+
+        $this->mockOpenAIClient->expects($this->once())
+            ->method('summarizeEmail')
+            ->with($emailContent)
+            ->willReturn($expectedSummary);
+
+        $summary = $this->summarizer->summarize($emailContent);
+        $this->assertEquals($expectedSummary, $summary);
+    }
+
+    public function testProcessEmail() {
+        $email = (object)[
+            'body' => 'This is a test email content.'
+        ];
+        $expectedSummary = 'Test summary';
+
+        $this->mockOpenAIClient->expects($this->once())
+            ->method('summarizeEmail')
+            ->with($email->body)
+            ->willReturn($expectedSummary);
+
+        $processedEmail = $this->summarizer->processEmail($email);
+        $this->assertEquals($expectedSummary, $processedEmail->summary);
+    }
+}


### PR DESCRIPTION
Add integration with OpenAI API for summarizing email responses.

* **New Classes**:
  - Add `OpenAIClient` class in `organizer/src/class/OpenAIClient.php` to handle HTTP calls using curl and summarize email content.
  - Add `ThreadEmailSummarizer` class in `organizer/src/class/ThreadEmailSummarizer.php` to use `OpenAIClient` for summarizing emails and processing email summaries.

* **Unit Tests**:
  - Add unit tests for `OpenAIClient` in `organizer/src/tests/OpenAIClientTest.php` to test HTTP requests and email summarization.
  - Add unit tests for `ThreadEmailSummarizer` in `organizer/src/tests/ThreadEmailSummarizerTest.php` to test email summarization and processing.

* **Documentation**:
  - Update `README.md` to include information about the new OpenAI API integration, configuration, usage, and running tests.
  - Update `.clinerules` to reflect the new capability of summarizing email responses using the OpenAI API and instructions for running related tests.

* **Development Container**:
  - Add `.devcontainer/devcontainer.json` to set up the development environment with necessary tasks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HNygard/offpost/pull/11?shareId=74a94079-be83-4e8d-9230-8c8902129fb5).