### PR TITLE
Add Vaadin 23 GUI for monitoring

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -128,3 +128,10 @@ services:
       - OIDC_CLIENT_ID=organizer
       - OIDC_CLIENT_SECRET=secret
       - OIDC_REDIRECT_URI=http://localhost:25081/callback
+
+  vaadin-gui:
+    build: ./vaadin-gui
+    networks:
+      - app-network
+    ports:
+      - "8080:8080"

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -72,3 +72,11 @@ services:
       - DB_USER=offpost
       - DB_PASSWORD_FILE=/run/secrets/postgres_password
     restart: unless-stopped
+
+  vaadin-gui:
+    build: ./vaadin-gui
+    networks:
+      - app-network
+    ports:
+      - "8080:8080"
+    restart: unless-stopped

--- a/vaadin-gui/pom.xml
+++ b/vaadin-gui/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>vaadin-gui</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>vaadin-gui</name>
+    <description>Vaadin 23 GUI for monitoring application</description>
+
+    <properties>
+        <java.version>11</java.version>
+        <vaadin.version>23.0.0</vaadin.version>
+        <spring-boot.version>2.5.4</spring-boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring-boot-starter</artifactId>
+            <version>${vaadin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-gui/src/main/java/com/example/Application.java
+++ b/vaadin-gui/src/main/java/com/example/Application.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/vaadin-gui/src/main/java/com/example/views/MonitoringView.java
+++ b/vaadin-gui/src/main/java/com/example/views/MonitoringView.java
@@ -1,0 +1,24 @@
+package com.example.views;
+
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.dependency.StyleSheet;
+
+@Route("monitoring")
+@PageTitle("Monitoring")
+@CssImport("./styles/shared-styles.css")
+@JsModule("@vaadin/vaadin-lumo-styles/presets/compact.js")
+@NpmPackage(value = "@fontsource/roboto", version = "4.5.0")
+@StyleSheet("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap")
+public class MonitoringView extends VerticalLayout {
+
+    public MonitoringView() {
+        Label monitoringLabel = new Label("Monitoring View");
+        add(monitoringLabel);
+    }
+}


### PR DESCRIPTION
Add a new Vaadin 23 GUI for monitoring the application.

* **Add Vaadin Project Configuration**
  - Add `vaadin-gui/pom.xml` with Maven configuration for Vaadin 23 project.
  - Define dependencies for Vaadin 23 and Spring Boot.
  - Set Java version to 11.

* **Create Main Application Class**
  - Add `vaadin-gui/src/main/java/com/example/Application.java`.
  - Annotate with `@SpringBootApplication`.
  - Add `main` method to run Spring Boot application.

* **Add Monitoring View**
  - Add `vaadin-gui/src/main/java/com/example/views/MonitoringView.java`.
  - Annotate with `@Route("monitoring")` and `@PageTitle("Monitoring")`.
  - Add a `VerticalLayout` with a `Label` for monitoring.

* **Update Docker Configuration**
  - Modify `docker-compose.dev.yaml` to add `vaadin-gui` service for development.
  - Set build context to `./vaadin-gui`.
  - Expose port 8080 for Vaadin GUI.
  - Modify `docker-compose.prod.yaml` to add `vaadin-gui` service for production.
  - Set build context to `./vaadin-gui`.
  - Expose port 8080 for Vaadin GUI.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HNygard/offpost/pull/12?shareId=c48100d0-fb39-455b-b005-9f9ddc6d862a).