### PR TITLE
Fix database connection in Github action test run

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -28,5 +28,20 @@ jobs:
     - name: Install dependencies
       run: cd organizer/src && composer install
 
+    - name: Start PostgreSQL service
+      run: docker-compose -f docker-compose.dev.yaml up -d postgres
+
+    - name: Wait for PostgreSQL to be ready
+      run: |
+        echo "Waiting for PostgreSQL to be ready..."
+        for i in {1..30}; do
+          if docker exec $(docker ps -q -f name=postgres) pg_isready -U offpost; then
+            echo "PostgreSQL is ready!"
+            break
+          fi
+          echo "Retrying in 1 second..."
+          sleep 1
+        done
+
     - name: Run tests
       run: cd organizer/src && vendor/bin/phpunit --exclude-group integration tests


### PR DESCRIPTION
Add steps to start and wait for PostgreSQL service in GitHub Actions workflow.

* Add a step to start the PostgreSQL service using `docker-compose` in `.github/workflows/php.yml`.
* Add a step to wait for PostgreSQL to be ready before running tests in `.github/workflows/php.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HNygard/offpost/pull/13?shareId=7e9b63e7-124a-4458-b46f-39846ffc7f7d).