### PR TITLE
Fix error in archive thread by using ThreadStorageManager

### DIFF
--- a/organizer/src/setSuccessForThreadAndDocument.php
+++ b/organizer/src/setSuccessForThreadAndDocument.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/auth.php';
 require_once __DIR__ . '/class/Threads.php';
+require_once __DIR__ . '/class/ThreadStorageManager.php';
 
 // Require authentication
 requireAuth();
@@ -17,7 +18,9 @@ function logDebug($text) {
 
 $entityId = $_GET['entityId'];
 $threadId = $_GET['threadId'];
-$threads = getThreadsForEntity($entityId);
+
+$storageManager = ThreadStorageManager::getInstance();
+$threads = $storageManager->getThreadsForEntity($entityId);
 
 $thread = null;
 foreach ($threads->threads as $thread1) {


### PR DESCRIPTION
Fixes #14

Include `ThreadStorageManager.php` in `setSuccessForThreadAndDocument.php`.

* Replace the existing call to `getThreadsForEntity()` with a call to `ThreadStorageManager::getInstance()->getThreadsForEntity($entityId)`.
* Create an instance of `ThreadStorageManager` and call `getThreadsForEntity($entityId)` to retrieve threads for the given entity ID.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HNygard/offpost/pull/15?shareId=ba533ae1-feef-41bc-b459-6c6dcff3099a).