### PR TITLE
Fix error in classifier

### DIFF
--- a/organizer/src/classify-email.php
+++ b/organizer/src/classify-email.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/auth.php';
 require_once __DIR__ . '/class/Threads.php';
 require_once __DIR__ . '/class/ThreadEmailClassifier.php';
+require_once __DIR__ . '/class/ThreadStorageManager.php';
 
 // Require authentication
 requireAuth();
@@ -13,7 +14,7 @@ function logDebug($message) {
 
 $entityId = $_GET['entityId'];
 $threadId = $_GET['threadId'];
-$threads = getThreadsForEntity($entityId);
+$threads = ThreadStorageManager::getInstance()->getThreadsForEntity($entityId);
 
 $thread = null;
 foreach ($threads->threads as $thread1) {
@@ -271,7 +272,7 @@ function secondsToHumanReadable($seconds) {
                                 <input type="checkbox"
                                        value="true"
                                        name="<?= $emailId . '-ignore' ?>"
-                                    <?= $email->ignore ? ' checked="checked"' : '' ?>> Ignore
+                                   <?= $email->ignore ? ' checked="checked"' : '' ?>> Ignore
                             </label>
                         </div>
 


### PR DESCRIPTION
Fixes #16

Include the `ThreadStorageManager` class in `organizer/src/classify-email.php`.

* Replace the call to `getThreadsForEntity()` with `ThreadStorageManager::getInstance()->getThreadsForEntity($entityId)` in `organizer/src/classify-email.php`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HNygard/offpost/pull/17?shareId=99653a77-b6d1-42a6-ba33-bf0e1fc8e478).